### PR TITLE
Fixes #3 : removes allowBackup from manifest

### DIFF
--- a/hfrecyclerview/src/main/AndroidManifest.xml
+++ b/hfrecyclerview/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.mikhaellopez.hfrecyclerview">
 
     <application
-        android:allowBackup="true"
         android:supportsRtl="true" />
 
 </manifest>


### PR DESCRIPTION
Library's manifest shouldn't have allowBackup attribute, developers would be able to decide right approach for themselves